### PR TITLE
Actualising compose network key reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ in the metadata network. Something like this is needed in docker-compose.yml:
 ```
 networks:
   default:
-    external:
-      name: metadata
+    name: metadata
+    external: true
 ```
 
 To set the IAM_ROLE in docker-compose.yml, add a IAM_ROLE variable like this:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,5 @@ services:
 
 networks:
   metadata:
-    external:
-      name: metadata
+    name: metadata
+    external: true


### PR DESCRIPTION
Docker compose commands output warnings like:
```
WARN[0000] network metadata: network.external.name is deprecated in favor of network.name 
```

Actualising compose network key with docker compose [reference](https://docs.docker.com/compose/networking/#use-a-pre-existing-network).