### PR TITLE
Add support for using SSO profiles by setting AWS_PROFILE

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_KEY
       - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - AWS_CREDENTIAL_EXPIRATION
       - DEFAULT_IAM_ROLE
     networks:
       metadata:

--- a/metadata_wrapper_linux.sh
+++ b/metadata_wrapper_linux.sh
@@ -5,8 +5,8 @@ if [ -z "${AWS_ACCESS_KEY_ID}" ]; then
   exit 1
 fi
 
-if [ -z "${AWS_SECRET_KEY}" ]; then
-  echo "Missing AWS_SECRET_KEY env variable!"
+if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+  echo "Missing AWS_SECRET_ACCCESS_KEY env variable!"
   exit 1
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,32 @@
 #!/bin/bash
 
+if [ "${AWS_PROFILE}" != "" ]; then
+  echo "AWS_PROFILE is set (${AWS_PROFILE}), exporting session credentials"
+
+  if aws sts get-caller-identity --profile "${AWS_PROFILE}" > /dev/null 2>&1; then
+    echo "Using existing SSO credentials for profile ${AWS_PROFILE}"
+
+    eval "$(aws configure export-credentials --profile ${AWS_PROFILE} --format env)"
+  else
+    if aws sso login --profile ${AWS_PROFILE}; then
+      echo "SSO login successful."
+
+      # Verify that credentials are available
+      echo "Validating credentials..."
+      if aws sts get-caller-identity --profile ${AWS_PROFILE} > /dev/null 2>&1; then
+        echo "AWS session credentials are valid and active for profile: ${AWS_PROFILE}"
+        eval "$(aws configure export-credentials --profile ${AWS_PROFILE} --format env)"
+      else
+        echo "AWS session credentials are not valid for profile ${AWS_PROFILE}"
+        exit 1
+      fi
+    fi
+  fi
+fi
+
 if [ -z "${AWS_ACCESS_KEY_ID}" ]; then
   if [ ! -f ~/.aws/credentials ]; then
-    echo "ERROR: ~/.aws/credentials does not exist and AWS_ACCESS_KEY_ID and AWS_SECRET_KEY are not set!"
+    echo "ERROR: Missing AWS credentials!"
     exit 1
   fi
 
@@ -29,6 +53,11 @@ fi
 if ! docker network ls --format "{{.Name}}" | grep -q -x metadata; then
   echo "Adding missing metadata network"
   docker network create -d bridge --subnet 169.254.169.0/24 metadata
+fi
+
+# Test that the credentials are valid
+if ! aws sts get-caller-identity > /dev/null 2>&1; then
+  echo "ERROR: Invalid AWS credentials!"
 fi
 
 docker-compose build metadata


### PR DESCRIPTION
When AWS_PROFILE env variable is set, use existing credentials or call aws sso login to get credentials. The credentials are then exported to environmental variables that are passed to the docker container.

There's no support for renewing expired credentials and the proxy needs to be restarted to renew the credentials.