### PR TITLE
Use Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:bullseye-backports
+FROM debian:bookworm
 
-RUN apt-get update && apt-get install -y golang-1.16-go make git docker.io dnsutils net-tools dnsutils
+RUN apt-get update && apt-get install -y golang-go make git docker.io dnsutils net-tools dnsutils
 
 RUN mkdir /opt/metadata
 COPY Makefile metadata_wrapper_linux.sh /opt/metadata/


### PR DESCRIPTION
Metadata-credentials-proxy is currently broken due to bullseye-backports being removed from mirrors. Update the image to use to Debian Bookworm. 